### PR TITLE
logrotate コマンドに size-ascending を追加

### DIFF
--- a/doc/en/html/macro/command/logrotate.html
+++ b/doc/en/html/macro/command/logrotate.html
@@ -32,6 +32,13 @@ logrotate 'halt'
 	    If the &lt;size&gt; is followed by K, the size is assumed to be in kilobytes.
 	    If the M is used, the size is in megabytes.</dd>
 
+	<dt class="macro">'size-ascending' &lt;size&gt;</dt>
+	<dd>When a log file size is over &lt;size&gt; byte, the log file is be rotated.<br>
+	    Assign indexes in ascending order of age. Once an index is assigned, it should not be changed.<br>
+	    The &lt;size&gt; value must be larger than 128.<br>
+	    If the &lt;size&gt; is followed by K, the size is assumed to be in kilobytes.
+	    If the M is used, the size is in megabytes.</dd>
+
 	<dt class="macro">'rotate' &lt;count&gt;</dt>
 	<dd>Log files are rotated &lt;count&gt; times before being removed.<br>
 	    The &lt;count&gt; value must be larger than 1.</dd>

--- a/doc/ja/html/macro/command/logrotate.html
+++ b/doc/ja/html/macro/command/logrotate.html
@@ -32,6 +32,12 @@ logrotate 'halt'
 	    &lt;size&gt;は128以上であること。<br>
 	    末尾に"K"があるとキロバイト単位、"M"があるとメガバイト単位になる。</dd>
 
+	<dt class="macro">'size-ascending' '&lt;size&gt;'</dt>
+	<dd>ログのサイズが&lt;size&gt;バイトを超えていれば、リネームを行う。<br>
+	    古い順番にインデックスを振る。一度割り当てたインデックスは変更しない。<br>
+	    &lt;size&gt;は128以上であること。<br>
+	    末尾に"K"があるとキロバイト単位、"M"があるとメガバイト単位になる。</dd>
+
 	<dt class="macro">'rotate' &lt;count&gt;</dt>
 	<dd>ログファイルの世代を&lt;count&gt;にする。<br>
 	    &lt;count&gt;は1以上であること。</dd>

--- a/teraterm/common/ttddecmnd.h
+++ b/teraterm/common/ttddecmnd.h
@@ -102,4 +102,4 @@
 #define LogOptTimestampType 7
 #define LogOptMax           LogOptTimestampType
 
-#define CMD_SIZE_ASCENDING "size-ascending"
+#define CmdString_SizeAscending "size-ascending"

--- a/teraterm/common/ttddecmnd.h
+++ b/teraterm/common/ttddecmnd.h
@@ -101,3 +101,5 @@
 #define LogOptIncScrBuff    6
 #define LogOptTimestampType 7
 #define LogOptMax           LogOptTimestampType
+
+#define CMD_SIZE_ASCENDING "size-ascending"

--- a/teraterm/common/tttypes.h
+++ b/teraterm/common/tttypes.h
@@ -122,7 +122,8 @@ typedef enum {
 // log rotate mode
 enum rotate_mode {
 	ROTATE_NONE,
-	ROTATE_SIZE
+	ROTATE_SIZE,
+	ROTATE_SIZE_ASCENDING,
 };
 
 // Log Timestamp Type

--- a/teraterm/teraterm/CMakeLists.txt
+++ b/teraterm/teraterm/CMakeLists.txt
@@ -418,7 +418,6 @@ endif(ENABLE_GDIPLUS)
 target_link_libraries(
   ${PACKAGE_NAME}
   PRIVATE
-  shlwapi
   common_static
   ttpcmn
   cyglib
@@ -448,6 +447,7 @@ target_link_libraries(
   user32
   uuid
   ws2_32
+  Shlwapi
   )
 
 if(ENABLE_GDIPLUS)

--- a/teraterm/teraterm/CMakeLists.txt
+++ b/teraterm/teraterm/CMakeLists.txt
@@ -447,7 +447,6 @@ target_link_libraries(
   user32
   uuid
   ws2_32
-  Shlwapi
   )
 
 if(ENABLE_GDIPLUS)

--- a/teraterm/teraterm/CMakeLists.txt
+++ b/teraterm/teraterm/CMakeLists.txt
@@ -418,6 +418,7 @@ endif(ENABLE_GDIPLUS)
 target_link_libraries(
   ${PACKAGE_NAME}
   PRIVATE
+  shlwapi
   common_static
   ttpcmn
   cyglib

--- a/teraterm/teraterm/filesys_log.cpp
+++ b/teraterm/teraterm/filesys_log.cpp
@@ -36,6 +36,7 @@
 #include <process.h>
 #include <windows.h>
 #include <assert.h>
+#include <shlwapi.h>
 
 #include "teraterm.h"
 #include "tttypes.h"
@@ -518,6 +519,49 @@ static inline void logfile_unlock(void)
 	LeaveCriticalSection(&g_filelog_lock);
 }
 
+
+// 最大のログファイルインデックスを取得する
+// 前提
+// FullName はユーザーが指定したファイル名
+// インデックス部分は .数値 の形式とする
+// 例
+// FullName: c:\hogehoge\teraterm.log
+// インデックス付きのログファイル名
+// c:\hogehoge\teraterm.log.1
+// c:\hogehoge\teraterm.log.2
+// ...
+// c:\hogehoge\teraterm.log.10
+//
+// →　この場合この関数は 10 を返す
+static int FindMaxLogIndex(wchar_t *FullName)
+{
+	int maxIndex = 0;
+	wchar_t *pattern;
+	aswprintf(&pattern, L"%s.*", FullName);
+
+	// FindFileFirst でファイルを検索し、最新のファイルのインデックスを取得
+	WIN32_FIND_DATAW FindFileData;
+	HANDLE hFind = FindFirstFileW(pattern, &FindFileData);
+	free(pattern);
+
+	if (hFind != INVALID_HANDLE_VALUE) {
+		do {
+			// ファイル名の最後の数字を取得
+			wchar_t *ext = PathFindExtensionW(FindFileData.cFileName);
+			if (ext != NULL) {
+				wchar_t *end;
+				int num = wcstol(ext + 1, &end, 10);
+				if (num > maxIndex) {
+					maxIndex = num;
+				}
+			}
+		} while (FindNextFileW(hFind, &FindFileData));
+		FindClose(hFind);
+	}
+	return maxIndex;
+}
+
+
 // ログをローテートする。
 // (2013.3.21 yutaka)
 static void LogRotate(PFileVar fv)
@@ -528,7 +572,7 @@ static void LogRotate(PFileVar fv)
 	if (fv->RotateMode == ROTATE_NONE)
 		return;
 
-	if (fv->RotateMode == ROTATE_SIZE) {
+	if (fv->RotateMode == ROTATE_SIZE || fv->RotateMode == ROTATE_SIZE_ASCENDING) {
 		if (fv->ByteCount <= fv->RotateSize)
 			return;
 		//OutputDebugPrintf("%s: mode %d size %ld\n", __FUNCTION__, fv->RotateMode, fv->ByteCount);
@@ -537,44 +581,61 @@ static void LogRotate(PFileVar fv)
 	}
 
 	logfile_lock();
+
 	// ログサイズを再初期化する。
 	fv->ByteCount = 0;
 
 	// いったん今のファイルをクローズして、別名のファイルをオープンする。
 	CloseFileSync(fv);
 
-	// 世代ローテーションのステップ数の指定があるか
-	if (fv->RotateStep > 0)
-		loopmax = fv->RotateStep;
+	if (fv->RotateMode == ROTATE_SIZE) {
+		// 世代ローテーションのステップ数の指定があるか
+		if (fv->RotateStep > 0)
+			loopmax = fv->RotateStep;
 
-	for (i = 1 ; i <= loopmax ; i++) {
-		wchar_t *filename;
-		aswprintf(&filename, L"%s.%d", fv->FullName, i);
-		DWORD attr = GetFileAttributesW(filename);
-		free(filename);
-		if (attr == INVALID_FILE_ATTRIBUTES)
-			break;
-	}
-	if (i > loopmax) {
-		// 世代がいっぱいになったら、最古のファイルから廃棄する。
-		i = loopmax;
-	}
+		for (i = 1 ; i <= loopmax ; i++) {
+			wchar_t *filename;
+			aswprintf(&filename, L"%s.%d", fv->FullName, i);
+			DWORD attr = GetFileAttributesW(filename);
+			free(filename);
+			if (attr == INVALID_FILE_ATTRIBUTES)
+				break;
+		}
+		if (i > loopmax) {
+			// 世代がいっぱいになったら、最古のファイルから廃棄する。
+			i = loopmax;
+		}
 
-	// 別ファイルにリネーム。
-	for (k = i-1 ; k >= 0 ; k--) {
-		wchar_t *oldfile;
-		if (k == 0)
-			oldfile = _wcsdup(fv->FullName);
-		else
-			aswprintf(&oldfile, L"%s.%d", fv->FullName, k);
+		// 別ファイルにリネーム。
+		for (k = i-1 ; k >= 0 ; k--) {
+			wchar_t *oldfile;
+			if (k == 0)
+				oldfile = _wcsdup(fv->FullName);
+			else
+				aswprintf(&oldfile, L"%s.%d", fv->FullName, k);
+			wchar_t *newfile;
+			aswprintf(&newfile, L"%s.%d", fv->FullName, k+1);
+			DeleteFileW(newfile);
+			if (MoveFileW(oldfile, newfile) == 0) {
+				OutputDebugPrintf("%s: rename %d\n", __FUNCTION__, errno);
+			}
+			free(oldfile);
+			free(newfile);
+		}
+	}
+	else if (fv->RotateMode == ROTATE_SIZE_ASCENDING) {
+		// 古いファイルから新しいファイルに　.1 から .n までのインデックスにリネームする
+		int maxIndex = FindMaxLogIndex(fv->FullName);
+
+		// 次のインデックス用に更新
+		maxIndex++;
+
+		// ファイルをリネーム
 		wchar_t *newfile;
-		aswprintf(&newfile, L"%s.%d", fv->FullName, k+1);
-		DeleteFileW(newfile);
-		if (MoveFileW(oldfile, newfile) == 0) {
+		aswprintf(&newfile, L"%s.%d", fv->FullName, maxIndex);
+		if (MoveFileW(fv->FullName, newfile) == 0) {
 			OutputDebugPrintf("%s: rename %d\n", __FUNCTION__, errno);
 		}
-		free(oldfile);
-		free(newfile);
 	}
 
 	// 再オープン
@@ -789,6 +850,24 @@ void FLogRotateSize(size_t size)
 	fv->RotateMode = ROTATE_SIZE;
 	fv->RotateSize = (LONG)size;
 }
+
+
+/**
+ *	ログローテートの設定
+ *	ログのサイズが<size>バイトを超えていれば、ローテーションするよう設定する
+ *  ただしインデックスは数字の小さいものが古く、数字の大きなものが新しいものとする
+ *  つまり最初に割り当てた数字は変わらない。
+ */
+void FLogRotateSizeAscending(size_t size)
+{
+	PFileVar fv = LogVar;
+	if (fv == NULL) {
+		return;
+	}
+	fv->RotateMode = ROTATE_SIZE_ASCENDING;
+	fv->RotateSize = (LONG)size;
+}
+
 
 /**
  *	ログローテートの設定

--- a/teraterm/teraterm/filesys_log.cpp
+++ b/teraterm/teraterm/filesys_log.cpp
@@ -636,6 +636,7 @@ static void LogRotate(PFileVar fv)
 		if (MoveFileW(fv->FullName, newfile) == 0) {
 			OutputDebugPrintf("%s: rename %d\n", __FUNCTION__, errno);
 		}
+		free(newfile);
 	}
 
 	// ÄƒI[ƒvƒ“

--- a/teraterm/teraterm/filesys_log.cpp
+++ b/teraterm/teraterm/filesys_log.cpp
@@ -59,6 +59,8 @@
 
 #define TitLog      L"Log"
 
+#pragma comment(lib, "Shlwapi.lib")
+
 /*
    Line Head flag for timestamping
    2007.05.24 Gentaro

--- a/teraterm/teraterm/filesys_log.h
+++ b/teraterm/teraterm/filesys_log.h
@@ -54,6 +54,7 @@ wchar_t *FLogGetLogFilenameBase(const wchar_t *filename);
 void logfile_lock_initialize(void);
 void FLogPause(BOOL Pause);
 void FLogRotateSize(size_t size);
+void FLogRotateSizeAscending(size_t size);
 void FLogRotateRotate(int step);
 void FLogRotateHalt(void);
 void FLogClose(void);

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -717,7 +717,9 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		if (strncmp(p, "size", 4) == 0) {
 			s = atoi(&p[5]);
 			FLogRotateSize(s);
-
+		} else if (strncmp(p, "size-ascending", sizeof("size-ascending") - 1 ) == 0) {
+			s = atoi(&p[sizeof("size-ascending")]);
+			FLogRotateSizeAscending(s);
 		} else if (strncmp(p, "rotate", 6) == 0) {
 			s = atoi(&p[7]);
 			FLogRotateRotate(s);

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -717,8 +717,8 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		if (strncmp(p, "size", 4) == 0) {
 			s = atoi(&p[5]);
 			FLogRotateSize(s);
-		} else if (strncmp(p, CMD_SIZE_ASCENDING, sizeof(CMD_SIZE_ASCENDING) - 1 ) == 0) {
-			s = atoi(&p[sizeof(CMD_SIZE_ASCENDING)]);
+		} else if (strncmp(p, CmdString_SizeAscending, sizeof(CmdString_SizeAscending) - 1 ) == 0) {
+			s = atoi(&p[sizeof(CmdString_SizeAscending)]);
 			FLogRotateSizeAscending(s);
 		} else if (strncmp(p, "rotate", 6) == 0) {
 			s = atoi(&p[7]);

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -717,8 +717,8 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		if (strncmp(p, "size", 4) == 0) {
 			s = atoi(&p[5]);
 			FLogRotateSize(s);
-		} else if (strncmp(p, "size-ascending", sizeof("size-ascending") - 1 ) == 0) {
-			s = atoi(&p[sizeof("size-ascending")]);
+		} else if (strncmp(p, CMD_SIZE_ASCENDING, sizeof(CMD_SIZE_ASCENDING) - 1 ) == 0) {
+			s = atoi(&p[sizeof(CMD_SIZE_ASCENDING)]);
 			FLogRotateSizeAscending(s);
 		} else if (strncmp(p, "rotate", 6) == 0) {
 			s = atoi(&p[7]);

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -3167,7 +3167,7 @@ static WORD TTLLogRotate(void)
 	if (Err!=0) return Err;
 
 	Err = ErrSyntax;
-	if (strcmp(Str, "size") == 0 || strcmp(Str, "size-ascending") == 0) {   // ローテートサイズ
+	if (strcmp(Str, "size") == 0 || strcmp(Str, CMD_SIZE_ASCENDING) == 0) {   // ローテートサイズ
 		if (CheckParameterGiven()) {
 			Err = 0;
 			size = 0;

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -3167,7 +3167,7 @@ static WORD TTLLogRotate(void)
 	if (Err!=0) return Err;
 
 	Err = ErrSyntax;
-	if (strcmp(Str, "size") == 0) {   // ローテートサイズ
+	if (strcmp(Str, "size") == 0 || strcmp(Str, "size-ascending") == 0) {   // ローテートサイズ
 		if (CheckParameterGiven()) {
 			Err = 0;
 			size = 0;

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -3167,7 +3167,7 @@ static WORD TTLLogRotate(void)
 	if (Err!=0) return Err;
 
 	Err = ErrSyntax;
-	if (strcmp(Str, "size") == 0 || strcmp(Str, CMD_SIZE_ASCENDING) == 0) {   // ローテートサイズ
+	if (strcmp(Str, "size") == 0 || strcmp(Str, CmdString_SizeAscending) == 0) {   // ローテートサイズ
 		if (CheckParameterGiven()) {
 			Err = 0;
 			size = 0;


### PR DESCRIPTION
logrotate コマンドに size-ascending を追加

```
logrotate 'size-ascending' '10K'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new log rotation mode that rotates log files in ascending order based on file size.
  - Enhanced log rotation commands with a "size-ascending" option for more flexible log management.
- **Documentation**
  - Updated both English and Japanese user guides to explain the new "size-ascending" parameter and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->