### PR TITLE
準備ステップの名前変更

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,12 +44,12 @@ jobs:
 
     - uses: msys2/setup-msys2@v2
 
-    - name: before_build (install_cygwin)
+    - name: install_cygwin
       run: |
         chcp 932
         buildtools/install_cygwin.bat
 
-    - name: before_build (install_innosetup)
+    - name: install_innosetup
       run: |
         chcp 932
         buildtools/install_innosetup.bat


### PR DESCRIPTION
準備ステップの名前変更

appveyor_vs2022_bat.yml の名前に引きずられた名前にしていたが、
appveyor 固有のイベント名だったため



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal build process naming for enhanced clarity, ensuring a more streamlined workflow while keeping all user-facing functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->