### PR TITLE
GetTickCount()をGetTickCount64()に置き換え

### DIFF
--- a/TTProxy/ProxyWSockHook.h
+++ b/TTProxy/ProxyWSockHook.h
@@ -471,7 +471,7 @@ private:
         in_addr addr;
         struct in6_addr addr6;
         char* buffer;
-        DWORD time;
+        ULONGLONG time;
         ConnectionInfo(ProxyInfo& proxy, String realhost):proxy(proxy), realhost(realhost), buffer(NULL) {
         }
         ~ConnectionInfo() {
@@ -664,7 +664,7 @@ private:
             ConnectionInfo* info = table.get(url);
             ::LeaveCriticalSection(&section);
             if (info != NULL) {
-                info->time = ::GetTickCount();
+                info->time = ::GetTickCount64();
                 return info;
             }
             ProxyInfo proxy;
@@ -688,8 +688,8 @@ private:
                 }
             }
             if (i >= countof(list)) {
-                DWORD now = ::GetTickCount();
-                DWORD max = 0;
+                ULONGLONG now = ::GetTickCount64();
+                ULONGLONG max = 0;
                 int index = -1;
                 for (i = 0; i < countof(list); i++) {
                     if (list[i] != NULL) {
@@ -709,7 +709,7 @@ private:
             info->addr6.s6_addr[11] = 0xff;
             info->addr6.s6_addr[15] = i + 1;
 
-            info->time = ::GetTickCount();
+            info->time = ::GetTickCount64();
             return info;
         }
     };

--- a/teraterm/common/compat_win.cpp
+++ b/teraterm/common/compat_win.cpp
@@ -239,7 +239,7 @@ static HWND WINAPI GetConsoleWindowLocal(void)
 	}
 
 	// Format a "unique" NewWindowTitle.
-	wsprintfA(pszNewWindowTitle, "%d/%d", GetTickCount(), GetCurrentProcessId());
+	wsprintfA(pszNewWindowTitle, "%I64u/%d", GetTickCount64(), GetCurrentProcessId());
 
 	// Change current window title.
 	SetConsoleTitleA(pszNewWindowTitle);

--- a/teraterm/common/dlglib.c
+++ b/teraterm/common/dlglib.c
@@ -153,13 +153,14 @@ void SetDlgPercent(HWND HDlg, int id_Item, int id_Progress, LONG a, LONG b, int 
 	}
 }
 
-void SetDlgTime(HWND HDlg, int id_Item, DWORD stime, int bytes)
+void SetDlgTime(HWND HDlg, int id_Item, ULONGLONG stime, int bytes)
 {
-	static int prev_elapsed;
-	int elapsed, rate;
+	static ULONGLONG prev_elapsed;
+	ULONGLONG elapsed;
+	int rate;
 	wchar_t buff[64];
 
-	elapsed = (GetTickCount() - stime) / 1000;
+	elapsed = (GetTickCount64() - stime) / 1000;
 
 	if (elapsed == 0) {
 		prev_elapsed = 0;
@@ -172,15 +173,15 @@ void SetDlgTime(HWND HDlg, int id_Item, DWORD stime, int bytes)
 	}
 	prev_elapsed = elapsed;
 
-	rate = bytes / elapsed;
+	rate = (int)(bytes / elapsed);
 	if (rate < 1200) {
-		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%d:%02d (%dBytes/s)", elapsed / 60, elapsed % 60, rate);
+		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%llu:%02llu (%dBytes/s)", elapsed / 60, elapsed % 60, rate);
 	}
 	else if (rate < 1200000) {
-		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%d:%02d (%d.%02dKB/s)", elapsed / 60, elapsed % 60, rate / 1000, rate / 10 % 100);
+		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%llu:%02llu (%d.%02dKB/s)", elapsed / 60, elapsed % 60, rate / 1000, rate / 10 % 100);
 	}
 	else {
-		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%d:%02d (%d.%02dMB/s)", elapsed / 60, elapsed % 60, rate / (1000 * 1000), rate / 10000 % 100);
+		_snwprintf_s(buff, _countof(buff), _TRUNCATE, L"%llu:%02llu (%d.%02dMB/s)", elapsed / 60, elapsed % 60, rate / (1000 * 1000), rate / 10000 % 100);
 	}
 
 	SetDlgItemTextW(HDlg, id_Item, buff);

--- a/teraterm/common/dlglib.h
+++ b/teraterm/common/dlglib.h
@@ -44,7 +44,7 @@ void SetRB(HWND HDlg, int R, int FirstId, int LastId);
 void GetRB(HWND HDlg, LPWORD R, int FirstId, int LastId);
 void SetDlgNum(HWND HDlg, int id_Item, LONG Num);
 void SetDlgPercent(HWND HDlg, int id_Item, int id_Progress, LONG a, LONG b, int *prog);
-void SetDlgTime(HWND HDlg, int id_Item, DWORD elapsed, int bytes);
+void SetDlgTime(HWND HDlg, int id_Item, ULONGLONG elapsed, int bytes);
 void SetDropDownList(HWND HDlg, int Id_Item, const char *List[], int nsel);
 void SetDropDownListW(HWND HDlg, int Id_Item, const wchar_t *List[], int nsel);
 LONG GetCurSel(HWND HDlg, int Id_Item);

--- a/teraterm/common/ttlib.c
+++ b/teraterm/common/ttlib.c
@@ -956,24 +956,24 @@ char *mctimelocal(const char *format, BOOL utc_flag)
  *	@return	経過時間の文字列
  *			不要になったらfree()すること
  */
-char *strelapsed(DWORD start_time)
+char *strelapsed(ULONGLONG start_time)
 {
 	size_t sizeof_strtime = 20;
 	char *strtime = malloc(sizeof_strtime);
 	int days, hours, minutes, seconds, msecs;
-	DWORD delta = GetTickCount() - start_time;
+	ULONGLONG delta = GetTickCount64() - start_time;
 
-	msecs = delta % 1000;
+	msecs = (int)(delta % 1000);
 	delta /= 1000;
 
-	seconds = delta % 60;
+	seconds = (int)(delta % 60);
 	delta /= 60;
 
-	minutes = delta % 60;
+	minutes = (int)(delta % 60);
 	delta /= 60;
 
-	hours = delta % 24;
-	days = delta / 24;
+	hours = (int)(delta % 24);
+	days = (int)(delta / 24);
 
 	_snprintf_s(strtime, sizeof_strtime, _TRUNCATE,
 		"%d %02d:%02d:%02d.%03d",

--- a/teraterm/common/ttlib.h
+++ b/teraterm/common/ttlib.h
@@ -137,7 +137,7 @@ DllExport BOOL HasMultiMonitorSupport();
 DllExport BOOL HasDnsQuery();
 DllExport BOOL HasBalloonTipSupport();
 DllExport char *mctimelocal(const char *format, BOOL utc_flag);
-char *strelapsed(DWORD start_time);
+char *strelapsed(ULONGLONG start_time);
 
 void b64encode(PCHAR dst, int dsize, PCHAR src, int len);
 DllExport int b64decode(PCHAR dst, int dsize, PCHAR src);

--- a/teraterm/common/tttypes.h
+++ b/teraterm/common/tttypes.h
@@ -869,7 +869,7 @@ typedef struct {
 
 	void *NotifyIcon;
 
-	DWORD ConnectedTime;
+	ULONGLONG ConnectedTime;
 
 	void (*Log1Byte)(BYTE b);
 	void (*Log1Bin)(BYTE b);

--- a/teraterm/teraterm/buffer.c
+++ b/teraterm/teraterm/buffer.c
@@ -115,7 +115,7 @@ static BOOL BoxSelect;			// TRUE=矩形選択 / FALSE=行選択
 static POINT ClickCell;			// クリックした文字cell
 static POINT SelectStartOld;	// 描画した選択領域、start
 static POINT SelectEndOld;		// 描画した選択領域、end
-static DWORD SelectStartTime;
+static ULONGLONG SelectStartTime;
 static POINT DblClkStart;
 static POINT DblClkEnd;
 
@@ -4749,7 +4749,7 @@ void BuffStartSelect(int Xw, int Yw, BOOL Box, BOOL Shift)
 	Selected = FALSE;
 
 	// 選択開始ガード
-	SelectStartTime = GetTickCount();
+	SelectStartTime = GetTickCount64();
 	Selecting = FALSE;
 
 	// push位置
@@ -4778,7 +4778,7 @@ void BuffChangeSelect(int Xw, int Yw, int NClick)
 
 	if (!Selecting) {
 		// 選択ガード?
-		if (GetTickCount() - SelectStartTime < ts.SelectStartDelay) {
+		if (GetTickCount64() - SelectStartTime < ts.SelectStartDelay) {
 			// ガード中
 			return;
 		}
@@ -4889,7 +4889,7 @@ void BuffEndSelect(int Xw, int Yw)
 	(void)Xw;
 	(void)Yw;
 	if (!Selecting) {
-		if (GetTickCount() - SelectStartTime < ts.SelectStartDelay) {
+		if (GetTickCount64() - SelectStartTime < ts.SelectStartDelay) {
 			// ガード時間以内なら
 			// 選択領域解除
 			SelectEnd = SelectStart;

--- a/teraterm/teraterm/commlib.c
+++ b/teraterm/teraterm/commlib.c
@@ -805,7 +805,7 @@ void CommStart(PComVar cv, LONG lParam, PTTSet ts)
 			break;
 	}
 	cv->Ready = TRUE;
-	cv->ConnectedTime = GetTickCount();
+	cv->ConnectedTime = GetTickCount64();
 }
 
 BOOL CommCanClose(PComVar cv)

--- a/teraterm/teraterm/filesys.cpp
+++ b/teraterm/teraterm/filesys.cpp
@@ -66,7 +66,7 @@ typedef struct {
 	LONG FileSize; // uint64_t FileSize;  TODO
 	LONG ByteCount; // uint64_t ByteCount;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 	BOOL FilePause;
 
 	BOOL FileRetrySend, FileRetryEcho, FileCRSend, FileReadEOF, BinaryMode;
@@ -118,7 +118,7 @@ static BOOL OpenFTDlg(PFileVar fv)
 	free(DlgCaption);
 
 	fv->FilePause = FALSE;
-	fv->StartTime = GetTickCount();
+	fv->StartTime = GetTickCount64();
 	fv->SendDlg = FTDlg; /* File send */
 
 	return TRUE;

--- a/teraterm/teraterm/filesys_log.cpp
+++ b/teraterm/teraterm/filesys_log.cpp
@@ -69,7 +69,7 @@ typedef struct {
 	LONG FileSize;		// ? 使っていない
 	LONG ByteCount;		// ファイルサイズ
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	enum enumLineEnd eLineEnd;
 
@@ -406,7 +406,7 @@ static BOOL LogStart(PFileVar fv, const wchar_t *fname)
 	}
 
 	fv->IsPause = FALSE;
-	fv->StartTime = GetTickCount();
+	fv->StartTime = GetTickCount64();
 
 	if (ts.DeferredLogWriteMode) {
 		StartThread(fv);

--- a/teraterm/teraterm/filesys_proto.cpp
+++ b/teraterm/teraterm/filesys_proto.cpp
@@ -92,7 +92,7 @@ static PFileVarProto FileVar = NULL;
 static PProtoDlg PtDlg = NULL;
 static BOOL cv_ProtoFlag = FALSE;
 
-static void _SetDlgTime(TFileVarProto *fv, DWORD elapsed, int bytes)
+static void _SetDlgTime(TFileVarProto *fv, ULONGLONG elapsed, int bytes)
 {
 	SetDlgTime(fv->HWin, IDC_PROTOELAPSEDTIME, elapsed, bytes);
 }

--- a/teraterm/teraterm/filesys_proto.h
+++ b/teraterm/teraterm/filesys_proto.h
@@ -153,7 +153,7 @@ typedef TFileVarProto *PFileVarProto;
 // UIなど情報表示用関数
 typedef struct InfoOp_ {
 	void (*InitDlgProgress)(struct FileVarProto *fv, int *CurProgStat);
-	void (*SetDlgTime)(struct FileVarProto *fv, DWORD elapsed, int bytes);
+	void (*SetDlgTime)(struct FileVarProto *fv, ULONGLONG elapsed, int bytes);
 	void (*SetDlgPacketNum)(struct FileVarProto *fv, LONG Num);
 	void (*SetDlgByteCount)(struct FileVarProto *fv, LONG Num);
 	void (*SetDlgPercent)(struct FileVarProto *fv, LONG a, LONG b, int *p);

--- a/teraterm/teraterm/ftdlg.cpp
+++ b/teraterm/teraterm/ftdlg.cpp
@@ -151,13 +151,13 @@ void CFileTransDlg::ChangeButton(BOOL PauseFlag)
 	}
 }
 
-void CFileTransDlg::RefreshNum(DWORD StartTime, LONG FileSize, LONG ByteCount)
+void CFileTransDlg::RefreshNum(ULONGLONG StartTime, LONG FileSize, LONG ByteCount)
 {
 	char NumStr[24];
 	double rate;
 	int rate2;
-	static DWORD prev_elapsed;
-	DWORD elapsed;
+	static ULONGLONG prev_elapsed;
+	ULONGLONG elapsed;
 
 	if (OpId == OpSendFile) {
 		if (StartTime == 0) {
@@ -165,17 +165,17 @@ void CFileTransDlg::RefreshNum(DWORD StartTime, LONG FileSize, LONG ByteCount)
 			prev_elapsed = 0;
 		}
 		else {
-			elapsed = (GetTickCount() - StartTime) / 1000;
+			elapsed = (GetTickCount64() - StartTime) / 1000;
 			if (elapsed != prev_elapsed && elapsed != 0) {
-				rate2 = ByteCount / elapsed;
+				rate2 = (int)(ByteCount / elapsed);
 				if (rate2 < 1200) {
-					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%d:%02d (%dBytes/s)", elapsed / 60, elapsed % 60, rate2);
+					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%llu:%02llu (%dBytes/s)", elapsed / 60, elapsed % 60, rate2);
 				}
 				else if (rate2 < 1200000) {
-					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%d:%02d (%d.%02dKB/s)", elapsed / 60, elapsed % 60, rate2 / 1000, rate2 / 10 % 100);
+					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%llu:%02llu (%d.%02dKB/s)", elapsed / 60, elapsed % 60, rate2 / 1000, rate2 / 10 % 100);
 				}
 				else {
-					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%d:%02d (%d.%02dMB/s)", elapsed / 60, elapsed % 60, rate2 / (1000*1000), rate2 / 10000 % 100);
+					_snprintf_s(NumStr, sizeof(NumStr), _TRUNCATE, "%llu:%02llu (%d.%02dMB/s)", elapsed / 60, elapsed % 60, rate2 / (1000*1000), rate2 / 10000 % 100);
 				}
 				SetDlgItemText(IDC_TRANS_ETIME, NumStr);
 				prev_elapsed = elapsed;

--- a/teraterm/teraterm/ftdlg.h
+++ b/teraterm/teraterm/ftdlg.h
@@ -57,7 +57,7 @@ public:
 
 	BOOL Create(HINSTANCE hInstance, Info *info);
 	void ChangeButton(BOOL PauseFlag);
-	void RefreshNum(DWORD StartTime, LONG FileSize, LONG ByteCount);
+	void RefreshNum(ULONGLONG StartTime, LONG FileSize, LONG ByteCount);
 
 private:
 	virtual BOOL OnCancel();

--- a/teraterm/teraterm/ftdlg_lite.cpp
+++ b/teraterm/teraterm/ftdlg_lite.cpp
@@ -174,8 +174,8 @@ public:
 	BOOL Pause;
 	BOOL check_2sec;
 	BOOL show;
-	DWORD prev_elapsed;
-	DWORD StartTime;
+	ULONGLONG prev_elapsed;
+	ULONGLONG StartTime;
 	BOOL HideDialog;
 
 	CFileTransLiteDlg::Observer *observer_;
@@ -215,7 +215,7 @@ BOOL CFileTransLiteDlg::Create(HINSTANCE hInstance, HWND hParent, const wchar_t 
 	}
 
 	pData->SetDlgItemTextA(IDC_TRANS_ETIME, "0:00");
-	pData->StartTime = GetTickCount();
+	pData->StartTime = GetTickCount64();
 	pData->prev_elapsed = 0;
 
 	return Ok;
@@ -232,10 +232,10 @@ void CFileTransLiteDlg::RefreshNum(size_t ByteCount, size_t FileSize)
 		return;
 	}
 
-	const DWORD now = GetTickCount();
+	const ULONGLONG now = GetTickCount64();
 
 	if (!pData->check_2sec) {
-		DWORD elapsed_ms = now - pData->StartTime;
+		ULONGLONG elapsed_ms = now - pData->StartTime;
 		if (elapsed_ms > 2 * 1000) {
 			// 2sec経過
 			pData->check_2sec = TRUE;
@@ -247,10 +247,10 @@ void CFileTransLiteDlg::RefreshNum(size_t ByteCount, size_t FileSize)
 	}
 
 	char NumStr[24];
-	DWORD elapsed = (now - pData->StartTime) / 1000;
+	ULONGLONG elapsed = (now - pData->StartTime) / 1000;
 	if (elapsed != pData->prev_elapsed && elapsed != 0) {
 		char elapsed_str[24];
-		_snprintf_s(elapsed_str, sizeof(elapsed_str), _TRUNCATE, "%ld:%02ld",
+		_snprintf_s(elapsed_str, sizeof(elapsed_str), _TRUNCATE, "%llu:%02llu",
 					elapsed / 60, elapsed % 60);
 
 		char speed_str[24];

--- a/teraterm/teraterm/sendmem.cpp
+++ b/teraterm/teraterm/sendmem.cpp
@@ -82,7 +82,7 @@ typedef struct SendMemTag {
 	size_t send_left;
 	size_t send_index;
 	BOOL waited;
-	DWORD last_send_tick;
+	ULONGLONG last_send_tick;
 	//
 	CFileTransLiteDlg *dlg;
 	class SendMemDlgObserver *dlg_observer;
@@ -377,7 +377,7 @@ void SendMemContinuously(void)
 	}
 
 	if (p->waited) {
-		if (GetTickCount() - p->last_send_tick < p->delay_tick) {
+		if (GetTickCount64() - p->last_send_tick < p->delay_tick) {
 			// ウエイトする
 			return;
 		}
@@ -518,7 +518,7 @@ void SendMemContinuously(void)
 	if (p->send_left != 0 && need_delay) {
 		// waitに入る
 		p->waited = TRUE;
-		p->last_send_tick = GetTickCount();
+		p->last_send_tick = GetTickCount64();
 		// タイマーはidleを動作させるために使用している
 		SetTimer(p->hWnd, p->timer_id, p->delay_tick, NULL);
 	}

--- a/teraterm/teraterm/teraterm.cpp
+++ b/teraterm/teraterm/teraterm.cpp
@@ -398,7 +398,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 	MSG msg;
 	for (;;) {
 		// idle状態でメッセージがない場合
-		DWORD idle_enter_tick = GetTickCount();
+		ULONGLONG idle_enter_tick = GetTickCount64();
 		BOOL sleep_enable = FALSE;
 		for (;;) {
 			// idle処理を行う
@@ -412,7 +412,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 			if (!continue_idle) {
 				// FALSEが戻ってきたらidle処理は不要
 				if (!sleep_enable) {
-					if (GetTickCount() - idle_enter_tick > 20) {
+					if (GetTickCount64() - idle_enter_tick > 20) {
 						// 20ms以上idle処理不要だったらSleep()を入れる
 						sleep_enable = TRUE;
 					}
@@ -423,7 +423,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 				lCount = 0;
 			}
 			else {
-				idle_enter_tick = GetTickCount();
+				idle_enter_tick = GetTickCount64();
 				sleep_enable = FALSE;
 			}
 

--- a/teraterm/teraterm/vtterm.c
+++ b/teraterm/teraterm/vtterm.c
@@ -196,8 +196,8 @@ static int FilterTop, FilterBottom, FilterLeft, FilterRight;
 static BOOL SavedIMEstatus;
 
 /* Beep over-used */
-static DWORD BeepStartTime = 0;
-static DWORD BeepSuppressTime = 0;
+static ULONGLONG BeepStartTime = 0;
+static ULONGLONG BeepSuppressTime = 0;
 static DWORD BeepOverUsedCount = 0;
 
 static _locale_t CLocale = NULL;
@@ -345,7 +345,7 @@ void ResetTerminal() /*reset variables but don't update screen */
 	LastPutCharacter = 0;
 
 	// Beep over-used
-	BeepStartTime = GetTickCount();
+	BeepStartTime = GetTickCount64();
 	BeepSuppressTime = BeepStartTime - ts.BeepSuppressTime * 1000;
 	BeepStartTime -= (ts.BeepOverUsedTime * 1000);
 	BeepOverUsedCount = ts.BeepOverUsedCount;
@@ -5398,8 +5398,8 @@ int VTParse()
 	while ((c>0) && (ChangeEmu==0)) {
 #if defined(DEBUG_DUMP_INPUTCODE)
 		{
-			static DWORD prev_tick;
-			DWORD now = GetTickCount();
+			static ULONGLONG prev_tick;
+			ULONGLONG now = GetTickCount64();
 			if (prev_tick == 0) prev_tick = now;
 			if (now - prev_tick > 1*1000) {
 				printf("\n");
@@ -5777,9 +5777,9 @@ static void VisualBell(void)
 
 static void RingBell(int type)
 {
-	DWORD now;
+	ULONGLONG now;
 
-	now = GetTickCount();
+	now = GetTickCount64();
 	if (now - BeepSuppressTime < ts.BeepSuppressTime * 1000) {
 		BeepSuppressTime = now;
 	}

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -2207,7 +2207,7 @@ void CVTWindow::OnKeyDown(WPARAM nChar, UINT nRepCnt, UINT nFlags)
 #if UNICODE_DEBUG
 	if (UnicodeDebugParam.CodePopupEnable)
 	{
-		const DWORD now = GetTickCount();
+		const ULONGLONG now = GetTickCount64();
 		switch(CtrlKeyState) {
 		case 0:
 			if (nChar == UnicodeDebugParam.CodePopupKey1) {

--- a/teraterm/teraterm/vtwin.h
+++ b/teraterm/teraterm/vtwin.h
@@ -72,7 +72,7 @@ private:
 #if UNICODE_DEBUG
 	TipWin *TipWinCodeDebug;
 	int CtrlKeyState;			// 0:開始/1:押す/2:離す/3:押す(表示状態)
-	DWORD CtrlKeyDownTick;	// 最初に押したtick
+	ULONGLONG CtrlKeyDownTick;	// 最初に押したtick
 #endif
 
 	// TipWin

--- a/teraterm/ttpfile/bplus.c
+++ b/teraterm/ttpfile/bplus.c
@@ -80,7 +80,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -162,7 +162,7 @@ static BOOL BPInit(TProto *pv, PComVar cv, PTTSet ts)
   fv->InfoOp->SetDlgProtoText(fv, "B-Plus");
 
   fv->InfoOp->InitDlgProgress(fv, &bv->ProgStat);
-  bv->StartTime = GetTickCount();
+  bv->StartTime = GetTickCount64();
 
   /* file name, file size */
   if (bv->BPMode==IdBPSend)
@@ -610,7 +610,7 @@ static BOOL FTCreateFile(PBPVar bv)
 	if (bv->ProgStat != -1) {
 		bv->ProgStat = 0;
 	}
-	bv->StartTime = GetTickCount();
+	bv->StartTime = GetTickCount64();
 
 	return TRUE;
 }

--- a/teraterm/ttpfile/kermit.c
+++ b/teraterm/ttpfile/kermit.c
@@ -79,7 +79,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -1086,7 +1086,7 @@ static BOOL KmtSendNextFile(PKmtVar kv)
 
 	kv->ByteCount = 0;
 	kv->ProgStat = 0;
-	kv->StartTime = GetTickCount();
+	kv->StartTime = GetTickCount64();
 
 	fv->InfoOp->SetDlgProtoFileName(fv, kv->FullName);
 	fv->InfoOp->SetDlgByteCount(fv, kv->ByteCount);
@@ -1191,7 +1191,7 @@ static BOOL KmtInit(TProto *pv, PComVar cv, PTTSet ts)
 
 	if (kv->KmtMode == IdKmtSend) {
 		fv->InfoOp->InitDlgProgress(fv, &kv->ProgStat);
-		kv->StartTime = GetTickCount();
+		kv->StartTime = GetTickCount64();
 	}
 	else {
 		kv->ProgStat = -1;
@@ -1347,7 +1347,7 @@ static BOOL FTCreateFile(PKmtVar kv)
 	if (kv->ProgStat != -1) {
 		kv->ProgStat = 0;
 	}
-	kv->StartTime = GetTickCount();
+	kv->StartTime = GetTickCount64();
 
 	return TRUE;
 }

--- a/teraterm/ttpfile/quickvan.c
+++ b/teraterm/ttpfile/quickvan.c
@@ -65,7 +65,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -192,7 +192,7 @@ static BOOL QVInit(TProto *pv, PComVar cv, PTTSet ts)
   fv->InfoOp->SetDlgProtoText(fv, "Quick-VAN");
 
   fv->InfoOp->InitDlgProgress(fv, &qv->ProgStat);
-  qv->StartTime = GetTickCount();
+  qv->StartTime = GetTickCount64();
 
   qv->SeqNum = 0;
   qv->FileNum = 0;
@@ -470,7 +470,7 @@ static BOOL FTCreateFile(PQVVar qv)
 	if (qv->ProgStat != -1) {
 		qv->ProgStat = 0;
 	}
-	qv->StartTime = GetTickCount();
+	qv->StartTime = GetTickCount64();
 
 	return TRUE;
 }
@@ -930,7 +930,7 @@ static void QVSendVFILE(PQVVar qv)
   /* file no. */
   qv->FileNum++;
   qv->ProgStat = 0;
-  qv->StartTime = GetTickCount();
+  qv->StartTime = GetTickCount64();
   i = 3;
   QVPutNum2(qv,qv->FileNum,&i);
   /* file name */

--- a/teraterm/ttpfile/raw.c
+++ b/teraterm/ttpfile/raw.c
@@ -38,7 +38,7 @@ typedef struct {
 	const char *FullName;	// Windows上のファイル名 UTF-8
 	BOOL FileOpen;
 	LONG ByteCount;
-	DWORD StartTime;
+	ULONGLONG StartTime;
 	PComVar cv;
 	enum {
 		STATE_FLUSH,		// 処理開始時に受信データを捨てる
@@ -148,12 +148,12 @@ static BOOL RawReadPacket(void *arg)
 	PComVar cv = rv->cv;
 	BYTE Buff[InBuffSize];
 	int BuffCount;
-	static DWORD prev_elapsed;
-	DWORD elapsed;
+	static ULONGLONG prev_elapsed;
+	ULONGLONG elapsed;
 
 	if (cv->InBuffCount > 0) {
 		if (rv->StartTime == 0) {
-			rv->StartTime = GetTickCount();
+			rv->StartTime = GetTickCount64();
 			prev_elapsed = rv->StartTime;
 			fv->InfoOp->SetDlgPacketNum(fv, 1);
 		}
@@ -166,7 +166,7 @@ static BOOL RawReadPacket(void *arg)
 		LeaveCriticalSection(&cv->InBuff_lock);
 		file->WriteFile(file, Buff, BuffCount);
 		rv->ByteCount += BuffCount;
-		elapsed = (GetTickCount() - prev_elapsed) / 250;
+		elapsed = (GetTickCount64() - prev_elapsed) / 250;
 		if (elapsed != prev_elapsed) {
 			prev_elapsed = elapsed;
 			fv->InfoOp->SetDlgByteCount(fv, rv->ByteCount);

--- a/teraterm/ttpfile/xmodem.c
+++ b/teraterm/ttpfile/xmodem.c
@@ -80,7 +80,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -299,7 +299,7 @@ static BOOL XInit(TProto *pv, PComVar cv, PTTSet ts)
 		xv->ProgStat = -1;
 	}
 	fv->InfoOp->SetDlgProtoFileName(fv, xv->FullName);
-	xv->StartTime = GetTickCount();
+	xv->StartTime = GetTickCount64();
 
 	xv->PktNumOffset = 0;
 	xv->PktNum = 0;

--- a/teraterm/ttpfile/ymodem.c
+++ b/teraterm/ttpfile/ymodem.c
@@ -72,7 +72,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -341,7 +341,7 @@ static void initialize_file_info(PYVar yv)
 	} else {
 		yv->ProgStat = -1;
 	}
-	yv->StartTime = GetTickCount();
+	yv->StartTime = GetTickCount64();
 	fv->InfoOp->SetDlgProtoFileName(fv, yv->FullName);
 
 	yv->PktNumOffset = 0;
@@ -501,7 +501,7 @@ static BOOL FTCreateFile(PYVar yv)
 	if (yv->ProgStat != -1) {
 		yv->ProgStat = 0;
 	}
-	yv->StartTime = GetTickCount();
+	yv->StartTime = GetTickCount64();
 
 	return TRUE;
 }

--- a/teraterm/ttpfile/zmodem.c
+++ b/teraterm/ttpfile/zmodem.c
@@ -116,7 +116,7 @@ typedef struct {
 
 	int ProgStat;
 
-	DWORD StartTime;
+	ULONGLONG StartTime;
 
 	DWORD FileMtime;
 
@@ -640,7 +640,7 @@ static void ZSendFileDat(PZVar zv)
 
 	zv->ByteCount = 0;
 	zv->ProgStat = 0;
-	zv->StartTime = GetTickCount();
+	zv->StartTime = GetTickCount64();
 	fv->InfoOp->SetDlgByteCount(fv, zv->ByteCount);
 	fv->InfoOp->SetDlgPercent(fv, zv->ByteCount, zv->FileSize, &zv->ProgStat);
 	fv->InfoOp->SetDlgTime(fv, zv->StartTime, zv->ByteCount);
@@ -746,7 +746,7 @@ static BOOL ZInit(TProto *pv, PComVar cv, PTTSet ts)
 	fv->InfoOp->SetDlgProtoText(fv, "ZMODEM");
 
 	fv->InfoOp->InitDlgProgress(fv, &zv->ProgStat);
-	zv->StartTime = GetTickCount();
+	zv->StartTime = GetTickCount64();
 
 	zv->FileSize = 0;
 	zv->FileMtime = 0;
@@ -1107,7 +1107,7 @@ static BOOL FTCreateFile(PZVar zv)
 	if (zv->ProgStat != -1) {
 		zv->ProgStat = 0;
 	}
-	zv->StartTime = GetTickCount();
+	zv->StartTime = GetTickCount64();
 
 	return TRUE;
 }
@@ -1169,7 +1169,7 @@ static BOOL ZParseFile(PZVar zv)
 	if (zv->FileSize > 0)
 		fv->InfoOp->SetDlgPercent(fv,
 					  0, zv->FileSize, &zv->ProgStat);
-	fv->InfoOp->SetDlgTime(fv, GetTickCount(), zv->ByteCount);
+	fv->InfoOp->SetDlgTime(fv, GetTickCount64(), zv->ByteCount);
 
 	/* set timeout for data */
 	fv->FTSetTimeOut(fv, zv->TimeOut);

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -81,7 +81,7 @@ static int EndIfFlag;
 static HWND HMainWin;
 // Timeout
 static DWORD TimeLimit;
-static DWORD TimeStart;
+static ULONGLONG TimeStart;
 // for 'WaitEvent' command
 static int WakeupCondition;
 
@@ -1577,7 +1577,7 @@ static WORD TTLFileLock(void)
 	DWORD timeout;
 	int result;
 	BOOL ret;
-	DWORD dwStart;
+	ULONGLONG dwStart;
 
 	Err = 0;
 	GetIntVal(&fhi,&Err);
@@ -1592,7 +1592,7 @@ static WORD TTLFileLock(void)
 	timeout = timeoutI * 1000;
 
 	result = 1;  // error
-	dwStart = GetTickCount();
+	dwStart = GetTickCount64();
 	do {
 		ret = LockFile(FH, 0, 0, (DWORD)-1, (DWORD)-1);
 		if (ret != 0) { // ロック成功
@@ -1600,7 +1600,7 @@ static WORD TTLFileLock(void)
 			break;
 		}
 		Sleep(1);
-	} while (GetTickCount() - dwStart < (timeout*1000));
+	} while (GetTickCount64() - dwStart < (timeout*1000));
 
 	SetResult(result);
 	return Err;
@@ -3446,7 +3446,7 @@ static WORD TTLPause(void)
 	{
 		TTLStatus = IdTTLPause;
 		TimeLimit = (DWORD)(TimeOut*1000);
-		TimeStart = GetTickCount();
+		TimeStart = GetTickCount64();
 		SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 	}
 	return Err;
@@ -3548,7 +3548,7 @@ static WORD TTLRecvLn(void)
 	if (TimeOut>0)
 	{
 		TimeLimit = (DWORD)TimeOut;
-		TimeStart = GetTickCount();
+		TimeStart = GetTickCount64();
 		SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 	}
 
@@ -5469,10 +5469,9 @@ static WORD TTLUptime(void)
 		Err = ErrSyntax;
 	if (Err!=0) return Err;
 
-	// Windows OSが起動してからの経過時間（ミリ秒）を取得する。ただし、49日を経過すると、0に戻る。
-	// GetTickCount64() API(Vista以降)を使うと、オーバーフローしなくなるが、そもそもTera Termでは
-	// 64bit変数をサポートしていないので、意味がない。
-	tick = GetTickCount();
+	// Windows OSが起動してからの経過時間（ミリ秒）を取得する。
+	// マクロ変数は32bitのため下位32bitのみ格納する。
+	tick = (DWORD)GetTickCount64();
 
 	SetIntVal(VarId, tick);
 
@@ -5533,7 +5532,7 @@ static WORD TTLWait(BOOL Ln)
 		if (TimeOut>0)
 		{
 			TimeLimit = (DWORD)TimeOut;
-			TimeStart = GetTickCount();
+			TimeStart = GetTickCount64();
 			SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 		}
 	}
@@ -5603,7 +5602,7 @@ static WORD TTLWaitEvent(void)
 	if (TimeOut>0)
 	{
 		TimeLimit = (DWORD)TimeOut;
-		TimeStart = GetTickCount();
+		TimeStart = GetTickCount64();
 		SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 	}
 
@@ -5645,7 +5644,7 @@ static WORD TTLWaitN(void)
 	if (TimeOut>0)
 	{
 		TimeLimit = (DWORD)TimeOut;
-		TimeStart = GetTickCount();
+		TimeStart = GetTickCount64();
 		SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 	}
 
@@ -5685,7 +5684,7 @@ static WORD TTLWaitRecv(void)
 	if (TimeOut>0)
 	{
 		TimeLimit = (DWORD)TimeOut;
-		TimeStart = GetTickCount();
+		TimeStart = GetTickCount64();
 		SetTimer(HMainWin, IdTimeOutTimer, TIMEOUT_TIMER_MS, NULL);
 	}
 	return Err;
@@ -6559,17 +6558,8 @@ void SetResult(int ResultCode)
 
 BOOL CheckTimeout()
 {
-	BOOL ret;
-	DWORD TimeUp = (TimeStart+TimeLimit);
-
-	if (TimeUp > TimeStart) {
-		ret = (GetTickCount() > TimeUp);
-	}
-	else { // for DWORD overflow (49.7 days)
-		DWORD TimeTmp = GetTickCount();
-		ret = (TimeUp < TimeTmp && TimeTmp >= TimeStart);
-	}
-	return ret;
+	ULONGLONG TimeUp = TimeStart + TimeLimit;
+	return (GetTickCount64() > TimeUp);
 }
 
 BOOL TestWakeup(int Wakeup)

--- a/teraterm/ttpmacro/ttmenc.c
+++ b/teraterm/ttpmacro/ttmenc.c
@@ -90,7 +90,7 @@ void Encrypt(const char *InStr, PCHAR OutStr)
 	if (InStr[0]==0) {
 		return;
 	}
-	srand(LOWORD(GetTickCount()));
+	srand((unsigned)GetTickCount64());
 	r = (BYTE)(rand() & 0x3f);
 	r2 = (~r) & 0x3f;
 	OutStr[0] = r;

--- a/ttssh2/ttxssh/ssh.c
+++ b/ttssh2/ttxssh/ssh.c
@@ -9039,24 +9039,24 @@ static INT_PTR CALLBACK ssh_scp_dlg_thread_proc(HWND hWnd, UINT msg, WPARAM wp, 
 				SendDlgItemMessage(hWnd, IDC_PROGBAR, PBM_SETPOS, (WPARAM)c->scp.ProgStat, 0);
 			}
 
-			int elapsed = (GetTickCount() - c->scp.stime) / 1000;
+			ULONGLONG elapsed = (GetTickCount64() - c->scp.stime) / 1000;
 			if (elapsed > c->scp.prev_elapsed) {
 				if (elapsed > 2) {
 					rate = (int)(transfered / elapsed);
 					if (rate < 1200) {
-						_snprintf_s(s, sizeof(s), _TRUNCATE, "%d:%02d (%d %s)", elapsed / 60, elapsed % 60, rate, "Bytes/s");
+						_snprintf_s(s, sizeof(s), _TRUNCATE, "%llu:%02llu (%d %s)", elapsed / 60, elapsed % 60, rate, "Bytes/s");
 					} else if (rate < 1200000) {
-						_snprintf_s(s, sizeof(s), _TRUNCATE, "%d:%02d (%d.%02d %s)", elapsed / 60, elapsed % 60, rate / 1000, rate / 10 % 100, "KBytes/s");
+						_snprintf_s(s, sizeof(s), _TRUNCATE, "%llu:%02llu (%d.%02d %s)", elapsed / 60, elapsed % 60, rate / 1000, rate / 10 % 100, "KBytes/s");
 					} else {
-						_snprintf_s(s, sizeof(s), _TRUNCATE, "%d:%02d (%d.%02d %s)", elapsed / 60, elapsed % 60, rate / (1000 * 1000), rate / 10000 % 100, "MBytes/s");
+						_snprintf_s(s, sizeof(s), _TRUNCATE, "%llu:%02llu (%d.%02d %s)", elapsed / 60, elapsed % 60, rate / (1000 * 1000), rate / 10000 % 100, "MBytes/s");
 					}
 				} else {
-					_snprintf_s(s, sizeof(s), _TRUNCATE, "%d:%02d", elapsed / 60, elapsed % 60);
+					_snprintf_s(s, sizeof(s), _TRUNCATE, "%llu:%02llu", elapsed / 60, elapsed % 60);
 				}
 				SendDlgItemMessage(hWnd, IDC_PROGTIME, WM_SETTEXT, 0, (LPARAM)s);
 				c->scp.prev_elapsed = elapsed;
 			}
-			c->scp.ProcessedTime = GetTickCount();
+			c->scp.ProcessedTime = GetTickCount64();
 			return FALSE;
 
 		case WM_COMMAND:
@@ -9137,7 +9137,7 @@ static unsigned __stdcall ssh_scp_dlg_thread(void *p)
 	c->scp.prev_elapsed = 0;
 	c->scp.filesndsize = 0;
 	c->scp.canceled = FALSE;
-	c->scp.stime = GetTickCount();
+	c->scp.stime = GetTickCount64();
 	c->scp.ProcessedTime = c->scp.stime;
 	SetWindowLongPtr(hDlgWnd, GWLP_USERDATA, (LONG_PTR)c);
 	SetTimer(hDlgWnd, c->self_id, SCPDLG_UPDATE_INTERVAL, NULL);
@@ -9174,7 +9174,7 @@ static HANDLE start_ssh_scp_dlg_thread(Channel_t *c)
 	// スレッド起動待ち
 	WaitForSingleObject(c->scp.ScpStartThreadEvent, 5000 /*msec*/);
 	ResetEvent(c->scp.ScpStartThreadEvent);
-	c->scp.stime = GetTickCount();
+	c->scp.stime = GetTickCount64();
 	return thread;
 }
 
@@ -9241,7 +9241,7 @@ static unsigned __stdcall ssh_scp_thread(void *p)
 		c->scp.filesndsize += ret;
 #if 1 // 高負荷対策
 		// 進捗ダイアログの描画が間に合わない場合は、負荷が下がるまで待つ
-		while (GetTickCount() - c->scp.ProcessedTime > SCPDLG_UPDATE_INTERVAL * 3) {
+		while (GetTickCount64() - c->scp.ProcessedTime > SCPDLG_UPDATE_INTERVAL * 3) {
 			Sleep(20);
 			if (pvar == NULL || pvar->socket == INVALID_SOCKET || c->scp.state == SCP_CLOSING || c->used == 0) {
 				goto cancel_abort;
@@ -9405,7 +9405,7 @@ static unsigned __stdcall ssh_scp_receive_thread(void *p)
 			}
 #if 1 // 高負荷対策
 			// 進捗ダイアログの描画が間に合わない場合は、負荷が下がるまで待つ
-			while (GetTickCount() - c->scp.ProcessedTime > SCPDLG_UPDATE_INTERVAL * 3) {
+			while (GetTickCount64() - c->scp.ProcessedTime > SCPDLG_UPDATE_INTERVAL * 3) {
 				Sleep(20);
 				if (pvar == NULL || pvar->socket == INVALID_SOCKET || c->scp.state == SCP_CLOSING || c->used == 0) {
 					goto cancel_abort;

--- a/ttssh2/ttxssh/ssh.h
+++ b/ttssh2/ttxssh/ssh.h
@@ -552,10 +552,10 @@ typedef struct scp {
 	PTInstVar pvar;
 	HANDLE ScpStartThreadEvent;
 	BOOL canceled;
-	DWORD stime;
-	int prev_elapsed;
+	ULONGLONG stime;
+	ULONGLONG prev_elapsed;
 	int ProgStat;
-	DWORD ProcessedTime;
+	ULONGLONG ProcessedTime;
 	// for receiving file
 	long long filetotalsize;
 	long long filercvsize;

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -604,7 +604,7 @@ static unsigned short find_local_port(PTInstVar pvar)
 	   if we're unlucky). They do not need to be (and are not)
 	   cryptographically strong.
 	 */
-	srand((unsigned) GetTickCount());
+	srand((unsigned)GetTickCount64());
 
 	for (tries = 20; tries > 0; tries--) {
 		memset(&hints, 0, sizeof(hints));


### PR DESCRIPTION
## Summary

- `GetTickCount()`（32bit、約49.7日でオーバーフロー）を`GetTickCount64()`（64bit）に全面置き換え
- 関連する変数の型を`DWORD`から`ULONGLONG`に変更
- `CheckTimeout()`のDWORDオーバーフロー対策コード（49.7日ラップアラウンド処理）を削除して簡略化
- `ttmenc.c`の`LOWORD(GetTickCount())`、フォーマット文字列`%d`→`%llu`なども合わせて修正

## 制約事項

`GetTickCount64()` は Windows Vista 以降で利用可能な API です。Windows XP 以前はサポート対象外となります。

## 変更ファイル一覧

| カテゴリ | ファイル |
|---|---|
| ヘッダー | `ssh.h`, `tttypes.h`, `filesys_proto.h`, `dlglib.h`, `ftdlg.h`, `vtwin.h`, `ttlib.h` |
| ファイル転送 | `bplus.c`, `quickvan.c`, `raw.c`, `xmodem.c`, `ymodem.c`, `zmodem.c`, `kermit.c` |
| UI/ダイアログ | `dlglib.c`, `ftdlg.cpp`, `ftdlg_lite.cpp`, `filesys_proto.cpp` |
| コア | `buffer.c`, `vtterm.c`, `vtwin.cpp`, `teraterm.cpp`, `commlib.c` |
| マクロ | `ttl.cpp`, `ttmenc.c` |
| SSH/SCP | `ssh.c`, `ssh.h`, `ttxssh.c` |
| その他 | `compat_win.cpp`, `ttlib.c`, `ProxyWSockHook.h`, `sendmem.cpp`, `filesys.cpp`, `filesys_log.cpp` |

## Test plan

- [x] ビルドが通ることを確認
- [ ] ファイル転送（ZMODEM/XMODEM/YMODEM/Kermit/B+/QuickVAN）が正常動作すること
- [ ] SCPファイル転送の進捗ダイアログが正常表示されること
- [ ] マクロのタイムアウト処理（`wait`/`waitregex`等）が正常動作すること
- [ ] OS起動から49.7日以上経過しても正しく経過時間が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)